### PR TITLE
Power network

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -110,6 +110,16 @@ impl TrainsApp {
 
                 let mut structures = Structures::new(HashMap::new());
                 structures.add_structure(Structure::new_sink(Vec2::new(0., 0.), 0.));
+                structures.add_structure(Structure::new_structure(
+                    StructureType::AtomicBattery,
+                    Vec2::new(15., 0.),
+                    0.,
+                ));
+                structures.add_structure(Structure::new_structure(
+                    StructureType::AtomicBattery,
+                    Vec2::new(-15., 0.),
+                    0.,
+                ));
 
                 (
                     Train::new(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -645,6 +645,10 @@ impl TrainsApp {
             self.building_structure = None;
         }
 
+        if !matches!(self.click_mode, ClickMode::ConnectWire) {
+            self.wire_start = None;
+        }
+
         if let Some(pointer) = response.hover_pos() {
             let pos = paint_transform.from_pos2(pointer);
             if let Some((id, node_pos)) = self

--- a/src/app.rs
+++ b/src/app.rs
@@ -59,6 +59,7 @@ enum ClickMode {
     AddWaterPump,
     AddBoiler,
     AddSteamEngine,
+    AddElectricPole,
     ConnectBelt,
     ConnectPipe,
     ConnectWire,
@@ -397,6 +398,14 @@ impl TrainsApp {
                             self.error_msg = Some((e, 10.));
                         }
                     }
+                    ClickMode::AddElectricPole => {
+                        if let Err(e) = self.add_hydrophoric_structure(
+                            paint_transform.from_pos2(pointer),
+                            StructureType::ElectricPole,
+                        ) {
+                            self.error_msg = Some((e, 10.));
+                        }
+                    }
                     ClickMode::ConnectBelt => {
                         if let Err(e) = self.add_belt(paint_transform.from_pos2(pointer)) {
                             self.error_msg = Some((e, 10.));
@@ -547,7 +556,8 @@ impl TrainsApp {
             | ClickMode::AddMerger
             | ClickMode::AddWaterPump
             | ClickMode::AddBoiler
-            | ClickMode::AddSteamEngine => {
+            | ClickMode::AddSteamEngine
+            | ClickMode::AddElectricPole => {
                 if let Some(pointer) = response.hover_pos() {
                     let ty = match self.click_mode {
                         ClickMode::AddSmelter => StructureType::Smelter,
@@ -556,6 +566,7 @@ impl TrainsApp {
                         ClickMode::AddWaterPump => StructureType::WaterPump,
                         ClickMode::AddBoiler => StructureType::Boiler,
                         ClickMode::AddSteamEngine => StructureType::SteamEngine,
+                        ClickMode::AddElectricPole => StructureType::ElectricPole,
                         _ => unreachable!(),
                     };
                     if let Some(pos) = self.building_structure {

--- a/src/app.rs
+++ b/src/app.rs
@@ -399,12 +399,12 @@ impl TrainsApp {
                         }
                     }
                     ClickMode::AddElectricPole => {
-                        if let Err(e) = self.add_hydrophoric_structure(
-                            paint_transform.from_pos2(pointer),
+                        let pos = paint_transform.from_pos2(pointer);
+                        self.structures.add_structure(Structure::new_structure(
                             StructureType::ElectricPole,
-                        ) {
-                            self.error_msg = Some((e, 10.));
-                        }
+                            pos,
+                            0.,
+                        ));
                     }
                     ClickMode::ConnectBelt => {
                         if let Err(e) = self.add_belt(paint_transform.from_pos2(pointer)) {
@@ -854,6 +854,11 @@ impl TrainsApp {
                 &mut self.click_mode,
                 ClickMode::AddSteamEngine,
                 "Add Steam Engine",
+            );
+            ui.radio_value(
+                &mut self.click_mode,
+                ClickMode::AddElectricPole,
+                "Add Electric Pole",
             );
             ui.radio_value(&mut self.click_mode, ClickMode::ConnectBelt, "Connect Belt");
             ui.radio_value(&mut self.click_mode, ClickMode::ConnectPipe, "Connect Pipe");

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,8 +16,8 @@ use self::heightmap::{CONTOURS_GRID_STEPE, HeightMapKey, HeightMapParams};
 use crate::{
     bg_image::BgImage,
     structure::{
-        BeltConnection, OreType, OreVein, PipeConnection, PowerStats, Structure, StructureId,
-        StructureType, Structures,
+        BeltConnection, MAX_WIRE_REACH, OreType, OreVein, PipeConnection, PowerStats, Structure,
+        StructureId, StructureType, Structures,
     },
     train::Train,
     train_tracks::{SelectedPathNode, Station, TrainTracks},
@@ -427,14 +427,8 @@ impl TrainsApp {
                         }
                     }
                     ClickMode::ConnectWire => {
-                        let clicked_pos = paint_transform.from_pos2(pointer);
-                        if let Some((wire_start, start_st)) = self.wire_start
-                            && let Some(end_st) = self.find_structure(clicked_pos)
-                        {
-                            self.structures.add_wire(start_st, end_st);
-                            self.wire_start = None;
-                        } else if let Some(start_st) = self.find_structure(clicked_pos) {
-                            self.wire_start = Some((clicked_pos, start_st));
+                        if let Err(e) = self.try_add_wire(pointer, &paint_transform) {
+                            self.error_msg = Some((e, 10.));
                         }
                     }
                     ClickMode::DeleteStructure => {

--- a/src/app/structure.rs
+++ b/src/app/structure.rs
@@ -13,7 +13,7 @@ use crate::{
     structure::{
         BELT_MAX_SLOPE, BELT_SPEED, Belt, BeltConnection, EntityId, FluidType, ITEM_INTERVAL, Item,
         MAX_BELT_LENGTH, MAX_FLUID_AMOUNT, MAX_WIRE_REACH, ORE_MINE_CAPACITY, Pipe, PipeConnection,
-        PowerWire, Structure, StructureId, StructureType,
+        Structure, StructureId, StructureType,
     },
     transform::PaintTransform,
     vec2::Vec2,
@@ -70,7 +70,7 @@ impl TrainsApp {
                     color = Color32::from_rgb(0, 255, 255);
                     y_pos = base_pos.y + BAR_OFFSET;
                 }
-                StructureType::ElectricPole => return Some(()),
+                StructureType::ElectricPole | StructureType::AtomicBattery => return Some(()),
             }
 
             painter.rect_filled(
@@ -314,6 +314,7 @@ impl TrainsApp {
                 StructureType::Boiler => Color32::from_rgb(255, 191, 127),
                 StructureType::SteamEngine => Color32::from_rgb(255, 127, 127),
                 StructureType::ElectricPole => Color32::from_rgb(255, 255, 63),
+                StructureType::AtomicBattery => Color32::from_rgb(63, 255, 63),
             }
         };
         let line_color = Color32::from_rgb(0, 63, 31);

--- a/src/app/structure.rs
+++ b/src/app/structure.rs
@@ -343,21 +343,25 @@ impl TrainsApp {
                 pos + paint_transform.to_vec2(Vec2::new(x, y))
             };
 
-            painter.add(PathShape::convex_polygon(
-                match ty {
-                    StructureType::Loader | StructureType::Unloader => {
-                        [[-4., -1.], [4., -1.], [4., 1.], [-4., 1.]]
+            if matches!(ty, StructureType::ElectricPole) {
+                painter.circle(pos, 0.2 * paint_transform.scale(), color, (1., line_color));
+            } else {
+                painter.add(PathShape::convex_polygon(
+                    match ty {
+                        StructureType::Loader | StructureType::Unloader => {
+                            [[-4., -1.], [4., -1.], [4., 1.], [-4., 1.]]
+                        }
+                        StructureType::Sink => [[-4., -4.], [4., -4.], [4., 4.], [-4., 4.]],
+                        StructureType::SteamEngine => [[-1., -2.], [1., -2.], [1., 2.], [-1., 2.]],
+                        _ => [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                     }
-                    StructureType::Sink => [[-4., -4.], [4., -4.], [4., 4.], [-4., 4.]],
-                    StructureType::SteamEngine => [[-1., -2.], [1., -2.], [1., 2.], [-1., 2.]],
-                    _ => [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                }
-                .into_iter()
-                .map(rotate)
-                .collect(),
-                color,
-                (1., line_color),
-            ));
+                    .into_iter()
+                    .map(rotate)
+                    .collect(),
+                    color,
+                    (1., line_color),
+                ));
+            }
 
             for (pos, local_orient) in ty.input_ports() {
                 render_triangle(
@@ -727,7 +731,7 @@ impl TrainsApp {
     }
 
     pub(super) fn render_wires(&mut self, painter: &Painter, paint_transform: &PaintTransform) {
-        let color = Color32::from_rgb(255, 255, 63);
+        let color = Color32::from_rgb(255, 127, 63);
         for wire in &self.structures.power_wires {
             if let Some((start_st, end_st)) = self
                 .structures

--- a/src/app/structure.rs
+++ b/src/app/structure.rs
@@ -463,6 +463,14 @@ impl TrainsApp {
                         );
                     }
                 }
+                EntityId::Wire(from, to) => {
+                    self.render_wire(
+                        (from, to),
+                        Color32::from_rgb(255, 0, 255),
+                        painter,
+                        paint_transform,
+                    );
+                }
                 _ => {}
             }
         }
@@ -731,23 +739,33 @@ impl TrainsApp {
         }
     }
 
+    fn render_wire(
+        &self,
+        wire: (StructureId, StructureId),
+        color: Color32,
+        painter: &Painter,
+        paint_transform: &PaintTransform,
+    ) {
+        if let Some((start_st, end_st)) = self
+            .structures
+            .structures
+            .get(&wire.0)
+            .zip(self.structures.structures.get(&wire.1))
+        {
+            painter.line_segment(
+                [
+                    paint_transform.to_pos2(start_st.pos),
+                    paint_transform.to_pos2(end_st.pos),
+                ],
+                (2., color),
+            );
+        }
+    }
+
     pub(super) fn render_wires(&mut self, painter: &Painter, paint_transform: &PaintTransform) {
         let color = Color32::from_rgb(255, 127, 63);
         for wire in &self.structures.power_wires {
-            if let Some((start_st, end_st)) = self
-                .structures
-                .structures
-                .get(&wire.0)
-                .zip(self.structures.structures.get(&wire.1))
-            {
-                painter.line_segment(
-                    [
-                        paint_transform.to_pos2(start_st.pos),
-                        paint_transform.to_pos2(end_st.pos),
-                    ],
-                    (2., color),
-                );
-            }
+            self.render_wire((wire.0, wire.1), color, painter, paint_transform);
         }
     }
 

--- a/src/app/structure.rs
+++ b/src/app/structure.rs
@@ -70,6 +70,7 @@ impl TrainsApp {
                     color = Color32::from_rgb(0, 255, 255);
                     y_pos = base_pos.y + BAR_OFFSET;
                 }
+                StructureType::ElectricPole => return Some(()),
             }
 
             painter.rect_filled(
@@ -312,6 +313,7 @@ impl TrainsApp {
                 StructureType::WaterPump => Color32::from_rgb(63, 127, 191),
                 StructureType::Boiler => Color32::from_rgb(255, 191, 127),
                 StructureType::SteamEngine => Color32::from_rgb(255, 127, 127),
+                StructureType::ElectricPole => Color32::from_rgb(255, 255, 63),
             }
         };
         let line_color = Color32::from_rgb(0, 63, 31);

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -127,6 +127,29 @@ impl StructureType {
             _ => &[],
         }
     }
+
+    /// Whether this structure can demand power. If true, it can be connected to power poles and be a part of
+    /// a power network.
+    pub(crate) fn power_sink(&self) -> bool {
+        use StructureType::*;
+        match self {
+            OreMine | Smelter => true,
+            Sink | Loader | Unloader | Splitter | Merger | Boiler | WaterPump | SteamEngine
+            | ElectricPole | AtomicBattery => false,
+        }
+    }
+
+    /// Whether this structure can supply power. If true, it can be connected to power poles and be a part of
+    /// a power network.
+    pub(crate) fn power_source(&self) -> bool {
+        use StructureType::*;
+        match self {
+            SteamEngine => true,
+            OreMine | Smelter | Sink | Loader | Unloader | Splitter | Merger | Boiler
+            | WaterPump | ElectricPole => false,
+            AtomicBattery => true,
+        }
+    }
 }
 
 impl Structure {
@@ -218,24 +241,13 @@ impl Structure {
     /// Whether this structure can demand power. If true, it can be connected to power poles and be a part of
     /// a power network.
     fn power_sink(&self) -> bool {
-        use StructureType::*;
-        match self.ty {
-            OreMine | Smelter => true,
-            Sink | Loader | Unloader | Splitter | Merger | Boiler | WaterPump | SteamEngine
-            | ElectricPole | AtomicBattery => false,
-        }
+        self.ty.power_sink()
     }
 
     /// Whether this structure can supply power. If true, it can be connected to power poles and be a part of
     /// a power network.
     fn power_source(&self) -> bool {
-        use StructureType::*;
-        match self.ty {
-            SteamEngine => true,
-            OreMine | Smelter | Sink | Loader | Unloader | Splitter | Merger | Boiler
-            | WaterPump | ElectricPole => false,
-            AtomicBattery => true,
-        }
+        self.ty.power_source()
     }
 
     /// Update this entity for one tick. It may try to send items to another by returning such a result.

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -80,6 +80,7 @@ pub(crate) enum StructureType {
     WaterPump,
     Boiler,
     SteamEngine,
+    ElectricPole,
 }
 
 impl StructureType {
@@ -98,7 +99,7 @@ impl StructureType {
             }
             Self::Merger => &STRUCTURE_INPUT_POS[..],
             Self::Sink => SINK,
-            Self::Unloader | Self::WaterPump | Self::SteamEngine => &[],
+            Self::Unloader | Self::WaterPump | Self::SteamEngine | Self::ElectricPole => &[],
             Self::Boiler => BOILER,
         }
     }
@@ -109,7 +110,12 @@ impl StructureType {
                 &STRUCTURE_OUTPUT_POS[0..1]
             }
             Self::Splitter => &STRUCTURE_OUTPUT_POS[..],
-            Self::Loader | Self::Sink | Self::WaterPump | Self::Boiler | Self::SteamEngine => &[],
+            Self::Loader
+            | Self::Sink
+            | Self::WaterPump
+            | Self::Boiler
+            | Self::SteamEngine
+            | Self::ElectricPole => &[],
         }
     }
 
@@ -202,7 +208,8 @@ impl Structure {
             | StructureType::Unloader
             | StructureType::Splitter
             | StructureType::Merger
-            | StructureType::Boiler => 0.,
+            | StructureType::Boiler
+            | StructureType::ElectricPole => 0.,
             StructureType::WaterPump => 0.5,
             StructureType::SteamEngine => {
                 if let Some(input) = &self.input_fluid
@@ -227,7 +234,8 @@ impl Structure {
             | StructureType::Merger
             | StructureType::Boiler
             | StructureType::WaterPump
-            | StructureType::SteamEngine => false,
+            | StructureType::SteamEngine
+            | StructureType::ElectricPole => false,
         }
     }
 
@@ -242,7 +250,8 @@ impl Structure {
             | StructureType::Splitter
             | StructureType::Merger
             | StructureType::Boiler
-            | StructureType::WaterPump => false,
+            | StructureType::WaterPump
+            | StructureType::ElectricPole => false,
         }
     }
 
@@ -455,6 +464,7 @@ impl Structure {
                     input.amount = after;
                 }
             }
+            StructureType::ElectricPole => {}
         }
         ret
     }

--- a/src/structure/power_network.rs
+++ b/src/structure/power_network.rs
@@ -1,0 +1,76 @@
+use super::{
+    // PowerWire,
+    StructureId,
+    Structures,
+};
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+pub(crate) const MAX_WIRE_REACH: f64 = 50.;
+
+#[derive(Eq, PartialEq, Hash, Copy, Clone, Serialize, Deserialize, Debug)]
+pub(crate) struct PowerWire(pub StructureId, pub StructureId);
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub(crate) struct PowerNetwork {
+    pub wires: Vec<PowerWire>,
+    pub sources: HashSet<StructureId>,
+    pub sinks: HashSet<StructureId>,
+}
+
+pub(crate) fn build_power_networks(
+    structures: &Structures,
+    power_wires: &[PowerWire],
+) -> Vec<PowerNetwork> {
+    let mut left_wires = power_wires.iter().collect::<HashSet<_>>();
+    let mut ret = vec![];
+
+    for (&id, s) in structures.structures.iter() {
+        if !s.power_sink() && !s.power_source() {
+            continue;
+        }
+        let mut expand_list = HashSet::<StructureId>::new();
+        let mut wires = vec![];
+        let mut sources = HashSet::new();
+        let mut sinks = HashSet::new();
+        if s.power_source() {
+            sources.insert(id);
+        }
+        if s.power_sink() {
+            sinks.insert(id);
+        }
+
+        expand_list.insert(id);
+
+        // Simple Dijkstra
+        while !expand_list.is_empty() {
+            let mut next_expand = HashSet::<StructureId>::new();
+            for id in expand_list {
+                if let Some(s) = structures.structures.get(&id) {
+                    if s.power_source() {
+                        sources.insert(id);
+                    }
+                    if s.power_sink() {
+                        sinks.insert(id);
+                    }
+                }
+                while let Some(wire) = left_wires.iter().find(|w| w.0 == id || w.1 == id).copied() {
+                    next_expand.insert(if wire.0 == id { wire.1 } else { wire.0 });
+                    left_wires.remove(&wire);
+                    wires.push(*wire);
+                }
+            }
+            expand_list = next_expand;
+        }
+
+        if !sources.is_empty() && !sinks.is_empty() {
+            ret.push(PowerNetwork {
+                wires,
+                sources,
+                sinks,
+            });
+        }
+    }
+    ret
+}


### PR DESCRIPTION
Now the power networks are build with electric poles and power wires that connect them. Each power network's supply and demand are calculated individually, so one section of the factory can go blackout while the others are intact.

Currently you can only see the connections and total amount of demand and supply on the right panel, but we will add a sub-network specific power statistics display.

<img width="802" height="632" alt="image" src="https://github.com/user-attachments/assets/3e14aa67-3648-43a9-8e5f-a121b6a6bcd3" />

Power wires are a new kind of entities that are part of the structures struct. They indicate bidirectional connections between structures, including electric poles.

You need to connect steam engines, ore mines and smelters in one network to set up operational pipeline.

<img width="802" height="632" alt="image" src="https://github.com/user-attachments/assets/d58f084a-4a83-4a74-8e5e-9ff2e94c14d2" />

## Atomic batteries

There is also a new structure type, AtomicBatter, which provides infinite power, but they are only provided 2 of them. They are used to set up initial ore mines to extract coal, which is required to bootstrap initial power production.

Tho 2 green structures around the center is the atomic batteries.

<img width="439" height="275" alt="image" src="https://github.com/user-attachments/assets/809f2790-1ce2-4b00-8fa0-a02f3d7b3db1" />
